### PR TITLE
Add CVE patches for libxml2 and libssh2

### DIFF
--- a/recipes/libssh2-1.9-patches/CVE-2019-17498-integer-overflow.patch
+++ b/recipes/libssh2-1.9-patches/CVE-2019-17498-integer-overflow.patch
@@ -1,0 +1,109 @@
+diff --git a/src/packet.c b/src/packet.c
+index 38ab629..2e01bfc 100644
+--- libssh2-1.9.0.orig/src/packet.c
++++ libssh2-1.9.0/src/packet.c
+@@ -419,8 +419,8 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                     size_t datalen, int macstate)
+ {
+     int rc = 0;
+-    char *message = NULL;
+-    char *language = NULL;
++    unsigned char *message = NULL;
++    unsigned char *language = NULL;
+     size_t message_len = 0;
+     size_t language_len = 0;
+     LIBSSH2_CHANNEL *channelp = NULL;
+@@ -472,33 +472,23 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+ 
+         case SSH_MSG_DISCONNECT:
+             if(datalen >= 5) {
+-                size_t reason = _libssh2_ntohu32(data + 1);
++                uint32_t reason = 0;
++                struct string_buf buf;
++                buf.data = (unsigned char *)data;
++                buf.dataptr = buf.data;
++                buf.len = datalen;
++                buf.dataptr++; /* advance past type */
+ 
+-                if(datalen >= 9) {
+-                    message_len = _libssh2_ntohu32(data + 5);
++                _libssh2_get_u32(&buf, &reason);
++                _libssh2_get_string(&buf, &message, &message_len);
++                _libssh2_get_string(&buf, &language, &language_len);
+ 
+-                    if(message_len < datalen-13) {
+-                        /* 9 = packet_type(1) + reason(4) + message_len(4) */
+-                        message = (char *) data + 9;
+-
+-                        language_len =
+-                            _libssh2_ntohu32(data + 9 + message_len);
+-                        language = (char *) data + 9 + message_len + 4;
+-
+-                        if(language_len > (datalen-13-message_len)) {
+-                            /* bad input, clear info */
+-                            language = message = NULL;
+-                            language_len = message_len = 0;
+-                        }
+-                    }
+-                    else
+-                        /* bad size, clear it */
+-                        message_len = 0;
+-                }
+                 if(session->ssh_msg_disconnect) {
+-                    LIBSSH2_DISCONNECT(session, reason, message,
+-                                       message_len, language, language_len);
++                    LIBSSH2_DISCONNECT(session, reason, (const char *)message,
++                                       message_len, (const char *)language,
++                                       language_len);
+                 }
++
+                 _libssh2_debug(session, LIBSSH2_TRACE_TRANS,
+                                "Disconnect(%d): %s(%s)", reason,
+                                message, language);
+@@ -539,24 +529,24 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 int always_display = data[1];
+ 
+                 if(datalen >= 6) {
+-                    message_len = _libssh2_ntohu32(data + 2);
+-
+-                    if(message_len <= (datalen - 10)) {
+-                        /* 6 = packet_type(1) + display(1) + message_len(4) */
+-                        message = (char *) data + 6;
+-                        language_len = _libssh2_ntohu32(data + 6 +
+-                                                        message_len);
+-
+-                        if(language_len <= (datalen - 10 - message_len))
+-                            language = (char *) data + 10 + message_len;
+-                    }
++                    struct string_buf buf;
++                    buf.data = (unsigned char *)data;
++                    buf.dataptr = buf.data;
++                    buf.len = datalen;
++                    buf.dataptr += 2; /* advance past type & always display */
++
++                    _libssh2_get_string(&buf, &message, &message_len);
++                    _libssh2_get_string(&buf, &language, &language_len);
+                 }
+ 
+                 if(session->ssh_msg_debug) {
+-                    LIBSSH2_DEBUG(session, always_display, message,
+-                                  message_len, language, language_len);
++                    LIBSSH2_DEBUG(session, always_display,
++                                  (const char *)message,
++                                  message_len, (const char *)language,
++                                  language_len);
+                 }
+             }
++
+             /*
+              * _libssh2_debug will actually truncate this for us so
+              * that it's not an inordinate about of data
+@@ -579,7 +569,7 @@ _libssh2_packet_add(LIBSSH2_SESSION * session, unsigned char *data,
+                 uint32_t len = 0;
+                 unsigned char want_reply = 0;
+                 len = _libssh2_ntohu32(data + 1);
+-                if(datalen >= (6 + len)) {
++                if((len <= (UINT_MAX - 6)) && (datalen >= (6 + len))) {
+                     want_reply = data[5 + len];
+                     _libssh2_debug(session,
+                                    LIBSSH2_TRACE_CONN,

--- a/recipes/libssh2-1.9.yaml
+++ b/recipes/libssh2-1.9.yaml
@@ -45,6 +45,7 @@ platforms:
       install_paths:
         license/libssh2:
           - COPYING
+      patches: libssh2-1.9-patches
       required_tools:
         - cmake
         - make
@@ -76,6 +77,7 @@ platforms:
       install_paths:
         license/libssh2:
           - COPYING
+      patches: libssh2-1.9-patches
       required_tools:
         - cmake
         - make
@@ -112,6 +114,7 @@ platforms:
           - src/Release/libssh2.lib
         license/libssh2:
           - COPYING
+      patches: libssh2-1.9-patches
       required_tools:
         - cmake
         - visualstudio=2017
@@ -145,6 +148,7 @@ platforms:
           - src/Release/libssh2.lib
         license/libssh2:
           - COPYING
+      patches: libssh2-1.9-patches
       required_tools:
         - cmake
         - visualstudio=2017

--- a/recipes/libxml2-2.9.10-patches/0001-Validate-UTF8-in-xmlEncodeEntities.patch
+++ b/recipes/libxml2-2.9.10-patches/0001-Validate-UTF8-in-xmlEncodeEntities.patch
@@ -1,0 +1,31 @@
+diff --git a/entities.c b/entities.c
+index d575e9d1..7cdbc4de 100644
+--- libxml2-2.9.10.orig/entities.c
++++ libxml2-2.9.10/entities.c
+@@ -666,11 +666,25 @@ xmlEncodeEntitiesInternal(xmlDocPtr doc, const xmlChar *input, int attr) {
+ 	    } else {
+ 		/*
+ 		 * We assume we have UTF-8 input.
++		 * It must match either:
++		 *   110xxxxx 10xxxxxx
++		 *   1110xxxx 10xxxxxx 10xxxxxx
++		 *   11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
++		 * That is:
++		 *   cur[0] is 11xxxxxx
++		 *   cur[1] is 10xxxxxx
++		 *   cur[2] is 10xxxxxx if cur[0] is 111xxxxx
++		 *   cur[3] is 10xxxxxx if cur[0] is 1111xxxx
++		 *   cur[0] is not 11111xxx
+ 		 */
+ 		char buf[11], *ptr;
+ 		int val = 0, l = 1;
+ 
+-		if (*cur < 0xC0) {
++		if (((cur[0] & 0xC0) != 0xC0) ||
++		    ((cur[1] & 0xC0) != 0x80) ||
++		    (((cur[0] & 0xE0) == 0xE0) && ((cur[2] & 0xC0) != 0x80)) ||
++		    (((cur[0] & 0xF0) == 0xF0) && ((cur[3] & 0xC0) != 0x80)) ||
++		    (((cur[0] & 0xF8) == 0xF8))) {
+ 		    xmlEntitiesErr(XML_CHECK_NOT_UTF8,
+ 			    "xmlEncodeEntities: input not UTF-8");
+ 		    if (doc != NULL)

--- a/recipes/libxml2-2.9.10-patches/CVE-2019-20388-mem-leak.patch
+++ b/recipes/libxml2-2.9.10-patches/CVE-2019-20388-mem-leak.patch
@@ -1,0 +1,12 @@
+diff --git a/xmlschemas.c b/xmlschemas.c
+index d19de6df..59495c27 100644
+--- libxml2-2.9.10.orig/xmlschemas.c
++++ libxml2-2.9.10/xmlschemas.c
+@@ -28095,7 +28095,6 @@ xmlSchemaPreRun(xmlSchemaValidCtxtPtr vctxt) {
+     vctxt->nberrors = 0;
+     vctxt->depth = -1;
+     vctxt->skipDepth = -1;
+-    vctxt->xsiAssemble = 0;
+     vctxt->hasKeyrefs = 0;
+ #ifdef ENABLE_IDC_NODE_TABLES_TEST
+     vctxt->createIDCNodeTables = 1;

--- a/recipes/libxml2-2.9.10-patches/CVE-2020-24977-buffer-overflow.patch
+++ b/recipes/libxml2-2.9.10-patches/CVE-2020-24977-buffer-overflow.patch
@@ -1,0 +1,17 @@
+diff --git a/xmllint.c b/xmllint.c
+index 735d951d..c0712674 100644
+--- libxml2-2.9.10.orig/xmllint.c
++++ libxml2-2.9.10/xmllint.c
+@@ -528,6 +528,12 @@ static void
+ xmlHTMLEncodeSend(void) {
+     char *result;
+ 
++    /*
++     * xmlEncodeEntitiesReentrant assumes valid UTF-8, but the buffer might
++     * end with a truncated UTF-8 sequence. This is a hack to at least avoid
++     * an out-of-bounds read.
++     */
++    memset(&buffer[sizeof(buffer)-4], 0, 4);
+     result = (char *) xmlEncodeEntitiesReentrant(NULL, BAD_CAST buffer);
+     if (result) {
+ 	xmlGenericError(xmlGenericErrorContext, "%s", result);

--- a/recipes/libxml2-2.9.10-patches/CVE-2020-7595-infinite-loop.patch
+++ b/recipes/libxml2-2.9.10-patches/CVE-2020-7595-infinite-loop.patch
@@ -1,0 +1,14 @@
+diff --git a/parser.c b/parser.c
+index d1c31963..a34bb6cd 100644
+--- libxml2-2.9.10.orig/parser.c
++++ libxml2-2.9.10/parser.c
+@@ -2646,7 +2646,8 @@ xmlStringLenDecodeEntities(xmlParserCtxtPtr ctxt, const xmlChar *str, int len,
+     else
+         c = 0;
+     while ((c != 0) && (c != end) && /* non input consuming loop */
+-	   (c != end2) && (c != end3)) {
++           (c != end2) && (c != end3) &&
++           (ctxt->instate != XML_PARSER_EOF)) {
+ 
+ 	if (c == 0) break;
+         if ((c == '&') && (str[1] == '#')) {

--- a/recipes/libxml2-2.9.yaml
+++ b/recipes/libxml2-2.9.yaml
@@ -36,6 +36,7 @@ platforms:
       install_paths:
         license/libxml2:
           - COPYING
+      patches: libxml2-2.9.10-patches
       required_tools:
         - make
         - clang
@@ -57,6 +58,7 @@ platforms:
       install_paths:
         license/libxml2:
           - COPYING
+      patches: libxml2-2.9.10-patches
       required_tools:
         - make
         - gcc
@@ -82,6 +84,7 @@ platforms:
           - win32/bin.msvc/libxml2.lib
         license/libxml2:
           - COPYING
+      patches: libxml2-2.9.10-patches
       required_tools:
         - visualstudio>=2017
     x86:
@@ -104,5 +107,6 @@ platforms:
           - win32/bin.msvc/libxml2.lib
         license/libxml2:
           - COPYING
+      patches: libxml2-2.9.10-patches
       required_tools:
         - visualstudio>=2017


### PR DESCRIPTION
Both the libxml2 project and libssh2 project have published CVEs that
are not presently patched in the current stable releases.

This commit adds patches for each.

Sources
-------

libxml2:

- CVE-2020-24977: https://gitlab.gnome.org/GNOME/libxml2/-/issues/178
- CVE-2020-7595:  https://gitlab.gnome.org/GNOME/libxml2/commit/0e1a49c89076
- CVE-2019-20388: https://gitlab.gnome.org/GNOME/libxml2/merge_requests/68

libssh2:

- CVE-2019-17498: https://github.com/libssh2/libssh2/pull/402/commits/1c6fa92b77e34d089493fe6d3e2c6c8775858b94