### PR TITLE
Use tool-variables for cmake VS generator names (0.3+)

### DIFF
--- a/recipes/libbz2-1.1-dev.yaml
+++ b/recipes/libbz2-1.1-dev.yaml
@@ -15,7 +15,7 @@
 name: libbz2
 version: "1.1.0"
 url: https://gitlab.com/federicomenaquintero/bzip2/-/archive/master/bzip2-master.tar.gz
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -23,9 +23,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -40,9 +41,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -58,9 +60,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -75,11 +78,12 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="{install}" \
             -DENABLE_STATIC_LIB=ON \
             -DENABLE_SHARED_LIB=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -94,7 +98,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -109,11 +113,11 @@ platforms:
       patches: patches_windows
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -128,4 +132,4 @@ platforms:
       patches: patches_windows
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libcheck-0.15.yaml
+++ b/recipes/libcheck-0.15.yaml
@@ -18,18 +18,20 @@ url: https://github.com/libcheck/check/archive/0.15.2.tar.gz
 archive_name_change:
   - 0.15.2
   - check-0.15.2
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
     host:
       build_script:
         configure: |
-          cmake . -DCMAKE_INSTALL_PREFIX={install}
+          cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX={install}
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
-          cmake --build . --config Release --target install
+          cmake --build . --target install
           install_name_tool -add_rpath @executable_path/../lib "{install}/lib/libcheck.dylib"
       install_paths:
         license/libcheck:
@@ -41,11 +43,13 @@ platforms:
     host:
       build_script:
         configure: |
-          cmake . -DCMAKE_INSTALL_PREFIX={install}
+          cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX={install}
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
-          cmake --build . --config Release --target install
+          cmake --build . --target install
           patchelf --set-rpath '$ORIGIN/../lib' "{install}/lib/libcheck.so"
       install_paths:
         license/libcheck:
@@ -58,7 +62,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64
         make: |
           CALL cmake.exe --build . --config Release
       install_paths:
@@ -72,11 +76,11 @@ platforms:
           - COPYING.LESSER
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32
         make: |
           CALL cmake.exe --build . --config Release
       install_paths:
@@ -90,4 +94,4 @@ platforms:
           - COPYING.LESSER
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -15,7 +15,7 @@
 name: libcurl
 version: "7.76.0"
 url: https://curl.haxx.se/download/curl-7.76.0.zip
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -23,7 +23,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-            -DCMAKE_CONFIGURATION_TYPES=Release \
+            -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_USE_OPENSSL=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -39,7 +39,7 @@ platforms:
             -DNGHTTP2_LIBRARY="{libs}/libnghttp2.dylib" \
             -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           install_name_tool -add_rpath @executable_path/../lib "{install}/lib/libcurl.dylib"
@@ -59,7 +59,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-            -DCMAKE_CONFIGURATION_TYPES=Release \
+            -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_USE_OPENSSL=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -75,7 +75,7 @@ platforms:
             -DNGHTTP2_LIBRARY="{libs}/libnghttp2.so" \
             -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           patchelf --set-rpath '$ORIGIN/../lib' "{install}/lib/libcurl.so"
@@ -95,7 +95,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-            -DCMAKE_CONFIGURATION_TYPES=Release \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_USE_OPENSSL=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
             -DOPENSSL_LIBRARIES="{libs}" \
@@ -111,7 +111,7 @@ platforms:
             -DCMAKE_INSTALL_PREFIX="{install}" \
             -DBUILD_SHARED_LIBS=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies:
@@ -129,8 +129,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64 \
-            -DCMAKE_CONFIGURATION_TYPES=Release \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64 \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_USE_OPENSSL=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -160,12 +159,11 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32 \
-            -DCMAKE_CONFIGURATION_TYPES=Release \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32 \
             -DBUILD_SHARED_LIBS=ON \
             -DCMAKE_USE_OPENSSL=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -195,4 +193,4 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libjson-c-0.15.yaml
+++ b/recipes/libjson-c-0.15.yaml
@@ -15,7 +15,7 @@
 name: libjson_c
 version: "0.15.0"
 url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.15.tar.gz
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -23,10 +23,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -41,10 +41,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -58,12 +58,12 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}" \
               -DBUILD_STATIC_LIBS=ON \
               -DBUILD_SHARED_LIBS=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -77,7 +77,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -105,11 +105,11 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -137,4 +137,4 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -18,7 +18,7 @@ url: https://github.com/nghttp2/nghttp2/archive/v1.43.0.zip
 archive_name_change:
   - v
   - nghttp2-
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -26,7 +26,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DBUILD_SHARED_LIBS=ON \
               -DOPENSSL_ROOT_DIR="{install}" \
               -DOPENSSL_INCLUDE_DIRS="{includes}" \
@@ -39,7 +39,7 @@ platforms:
               -DZLIB_LIBRARY="{libs}/libz.a" \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           install_name_tool -add_rpath @executable_path/../lib "{install}/lib/libnghttp2.dylib"
@@ -59,7 +59,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DBUILD_SHARED_LIBS=ON \
               -DOPENSSL_ROOT_DIR="{install}" \
               -DOPENSSL_INCLUDE_DIRS="{includes}" \
@@ -72,7 +72,7 @@ platforms:
               -DZLIB_LIBRARY="{libs}/libz.a" \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           patchelf --set-rpath '$ORIGIN/../lib' "{install}/lib/libnghttp2.so"
@@ -92,7 +92,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+              -DCMAKE_BUILD_TYPE=Release \
               -DOPENSSL_ROOT_DIR="{install}" \
               -DOPENSSL_INCLUDE_DIRS="{includes}" \
               -DOPENSSL_LIBRARIES="{libs}" \
@@ -107,7 +107,7 @@ platforms:
               -DENABLE_STATIC_LIB=ON \
               -DENABLE_SHARED_LIB=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies:
@@ -125,8 +125,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64 \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64 \
               -DBUILD_SHARED_LIBS=ON \
               -DOPENSSL_ROOT_DIR="{install}" \
               -DOPENSSL_INCLUDE_DIRS="{includes}" \
@@ -149,12 +148,11 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32 \
-              -DCMAKE_CONFIGURATION_TYPES=Release \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32 \
               -DBUILD_SHARED_LIBS=ON \
               -DOPENSSL_ROOT_DIR="{install}" \
               -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -177,4 +175,4 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libpcre2-10.yaml
+++ b/recipes/libpcre2-10.yaml
@@ -15,14 +15,17 @@
 name: libpcre2
 version: "10.36"
 url: https://ftp.pcre.org/pub/pcre/pcre2-10.36.tar.gz
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
     host:
       build_script:
         configure: |
-          ./configure --prefix="{install}" --disable-dependency-tracking --disable-static
+          ./configure \
+            --prefix="{install}" \
+            --disable-dependency-tracking \
+            --disable-static
         make: |
           make
         install: |
@@ -41,7 +44,9 @@ platforms:
     host:
       build_script:
         configure: |
-          ./configure --prefix="{install}" --disable-dependency-tracking --disable-static
+          ./configure --prefix="{install}" \
+            --disable-dependency-tracking \
+            --disable-static
         make: |
           make
         install: |
@@ -60,7 +65,9 @@ platforms:
     host-static:
       build_script:
         configure: |
-          ./configure --prefix="{install}" --disable-dependency-tracking --disable-shared
+          ./configure --prefix="{install}" \
+            --disable-dependency-tracking \
+            --disable-shared
         make: |
           make
         install: |
@@ -78,7 +85,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64 \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64 \
               -DBUILD_SHARED_LIBS=ON \
               -DZLIB_INCLUDE_DIR="{includes}" \
               -DZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
@@ -99,11 +106,11 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32 \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32 \
               -DBUILD_SHARED_LIBS=ON \
               -DZLIB_INCLUDE_DIR="{includes}" \
               -DZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
@@ -124,4 +131,4 @@ platforms:
           - COPYING
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libssh2-1.9.yaml
+++ b/recipes/libssh2-1.9.yaml
@@ -15,7 +15,7 @@
 name: libssh2
 version: "1.9.0"
 url: https://www.libssh2.org/download/libssh2-1.9.0.tar.gz
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -23,6 +23,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCRYPTO_BACKEND=OpenSSL \
             -DBUILD_SHARED_LIBS=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -35,7 +36,7 @@ platforms:
             -DCMAKE_INSTALL_PREFIX="{install}" \
             -DBUILD_TESTING=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           install_name_tool -add_rpath @executable_path/../lib "{install}/lib/libssh2.dylib"
@@ -55,6 +56,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCRYPTO_BACKEND=OpenSSL \
             -DBUILD_SHARED_LIBS=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -67,7 +69,7 @@ platforms:
             -DCMAKE_INSTALL_PREFIX="{install}" \
             -DBUILD_TESTING=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
           patchelf --set-rpath '$ORIGIN/../lib' "{install}/lib/libssh2.so"
@@ -87,6 +89,7 @@ platforms:
       build_script:
         configure: |
           cmake . \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCRYPTO_BACKEND=OpenSSL \
             -DBUILD_SHARED_LIBS=OFF \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -99,7 +102,7 @@ platforms:
             -DCMAKE_INSTALL_PREFIX="{install}" \
             -DBUILD_TESTING=OFF
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies:
@@ -117,7 +120,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A x64 \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64 \
             -DCRYPTO_BACKEND=OpenSSL\
             -DBUILD_SHARED_LIBS=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -147,11 +150,11 @@ platforms:
       patches: libssh2-1.9-patches
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL cmake.exe -G "Visual Studio 15 2017" -A Win32 \
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32 \
             -DCRYPTO_BACKEND=OpenSSL\
             -DBUILD_SHARED_LIBS=ON \
             -DOPENSSL_INCLUDE_DIR="{includes}" \
@@ -181,4 +184,4 @@ platforms:
       patches: libssh2-1.9-patches
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/recipes/libz-1.2.11.yaml
+++ b/recipes/libz-1.2.11.yaml
@@ -15,7 +15,7 @@
 name: libz
 version: "1.2.11"
 url: https://www.zlib.net/zlib-1.2.11.tar.gz
-mussels_version: "0.2"
+mussels_version: "0.3"
 type: recipe
 platforms:
   Darwin:
@@ -23,9 +23,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -41,9 +42,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -58,9 +60,10 @@ platforms:
       build_script:
         configure: |
           cmake . \
+              -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX="{install}"
         make: |
-          cmake --build . --config Release
+          cmake --build .
         install: |
           make install
       dependencies: []
@@ -75,8 +78,7 @@ platforms:
     x64:
       build_script:
         configure: |
-          CALL vcvarsall.bat amd64
-          CALL cmake.exe -G "Visual Studio 15 2017 Win64"
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A x64
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -90,12 +92,11 @@ platforms:
           - README
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
-          CALL vcvarsall.bat x86
-          CALL cmake.exe -G "Visual Studio 15 2017"
+          CALL cmake.exe . -G "{visualstudio.cmake_generator}" -A Win32
         make: |
           CALL cmake.exe --build . --config Release
       dependencies: []
@@ -109,4 +110,4 @@ platforms:
           - README
       required_tools:
         - cmake
-        - visualstudio=2017
+        - visualstudio>=2017

--- a/tools/visualstudio/visualstudio-2017.yaml
+++ b/tools/visualstudio/visualstudio-2017.yaml
@@ -14,7 +14,7 @@
 
 name: visualstudio
 version: "2017"
-mussels_version: "0.1"
+mussels_version: "0.3"
 type: tool
 platforms:
   Windows:
@@ -22,3 +22,5 @@ platforms:
       - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Professional/VC/Auxiliary/Build/vcvarsall.bat
       - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Enterprise/VC/Auxiliary/Build/vcvarsall.bat
       - C:\/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build/vcvarsall.bat
+    variables:
+      cmake_generator: Visual Studio 15 2017

--- a/tools/visualstudio/visualstudio-2019.yaml
+++ b/tools/visualstudio/visualstudio-2019.yaml
@@ -14,7 +14,7 @@
 
 name: visualstudio
 version: "2019"
-mussels_version: "0.1"
+mussels_version: "0.3"
 type: tool
 platforms:
   Windows:
@@ -22,3 +22,5 @@ platforms:
       - C:\/Program Files (x86)/Microsoft Visual Studio/2019/Professional/VC/Auxiliary/Build/vcvarsall.bat
       - C:\/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvarsall.bat
       - C:\/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvarsall.bat
+    variables:
+      cmake_generator: Visual Studio 16 2019


### PR DESCRIPTION
Use the new tool-variables feature to pass the cmake generator names for visual studio versions to recipe build scripts.