### PR TITLE
Bump versions for upcoming 0.103.2 release

### DIFF
--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "7.74.0"
-url: https://curl.haxx.se/download/curl-7.74.0.zip
+version: "7.76.0"
+url: https://curl.haxx.se/download/curl-7.76.0.zip
 mussels_version: "0.2"
 type: recipe
 platforms:

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libnghttp2
-version: "1.42.0"
-url: https://github.com/nghttp2/nghttp2/archive/v1.42.0.zip
+version: "1.43.0"
+url: https://github.com/nghttp2/nghttp2/archive/v1.43.0.zip
 archive_name_change:
   - v
   - nghttp2-

--- a/recipes/libopenssl-1.1.yaml
+++ b/recipes/libopenssl-1.1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libopenssl
-version: "1.1.1i"
-url: https://www.openssl.org/source/openssl-1.1.1i.tar.gz
+version: "1.1.1k"
+url: https://www.openssl.org/source/openssl-1.1.1k.tar.gz
 mussels_version: "0.2"
 type: recipe
 platforms:


### PR DESCRIPTION
libcurl: 7.74 -> 7.76

nghttp2: 1.42 -> 1.43

openssl: 1.1.1i -> 1.1.1k