### PR TITLE
Add static builds for Windows

### DIFF
--- a/collections/clamav_deps-0.104.yaml
+++ b/collections/clamav_deps-0.104.yaml
@@ -107,3 +107,27 @@ platforms:
         - libbz2<1.1.0
         - pdcurses
         - libcheck
+    x64-static:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - pthreads_win32
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - pdcurses
+        - libcheck
+    x86-static:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - pthreads_win32
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - pdcurses
+        - libcheck

--- a/recipes/libbz2-1.1-dev.yaml
+++ b/recipes/libbz2-1.1-dev.yaml
@@ -184,6 +184,28 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D ENABLE_STATIC_LIB=ON \
+            -D ENABLE_SHARED_LIB=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies: []
+      install_paths:
+        license/libbz2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -191,6 +213,28 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
             -D CMAKE_INSTALL_PREFIX="{install}"
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies: []
+      install_paths:
+        license/libbz2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D ENABLE_STATIC_LIB=ON \
+            -D ENABLE_SHARED_LIB=OFF
         make: |
           cd build
           CALL cmake.exe --build . --config Release

--- a/recipes/libcheck-0.15.yaml
+++ b/recipes/libcheck-0.15.yaml
@@ -178,7 +178,47 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}"
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+          mv {install}/bin/checkDynamic.dll {install}/lib/
+      install_paths:
+        license/libcheck:
+          - COPYING.LESSER
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}"
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+          mv {install}/bin/checkDynamic.dll {install}/lib/
+      install_paths:
+        license/libcheck:
+          - COPYING.LESSER
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
       build_script:
         configure: |
           mkdir build

--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -303,6 +303,40 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=ON \
+            -D CMAKE_USE_OPENSSL=ON \
+            -D OPENSSL_INCLUDE_DIR="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D LIBSSH2_INCLUDE_DIR="{includes}" \
+            -D LIBSSH2_LIBRARY="{libs}/libssh2.lib" \
+            -D BUILD_SHARED_LIBS=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies:
+        - libopenssl
+        - libnghttp2>=1.0.0
+        - libssh2
+        - libz
+      install_paths:
+        license/libcurl:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -329,6 +363,40 @@ platforms:
           cd build
           CALL cmake.exe --build . --config Release --target install
           mv {install}/bin/libcurl.dll {install}/lib/
+      dependencies:
+        - libopenssl
+        - libnghttp2>=1.0.0
+        - libssh2
+        - libz
+      install_paths:
+        license/libcurl:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=ON \
+            -D CMAKE_USE_OPENSSL=ON \
+            -D OPENSSL_INCLUDE_DIR="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D LIBSSH2_INCLUDE_DIR="{includes}" \
+            -D LIBSSH2_LIBRARY="{libs}/libssh2.lib" \
+            -D BUILD_SHARED_LIBS=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
       dependencies:
         - libopenssl
         - libnghttp2>=1.0.0

--- a/recipes/libjson-c-0.15.yaml
+++ b/recipes/libjson-c-0.15.yaml
@@ -181,6 +181,28 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_STATIC_LIBS=ON \
+            -D BUILD_SHARED_LIBS=OFF \
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies: []
+      install_paths:
+        license/libjson_c:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -194,7 +216,28 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
-          mv {install}/bin/json-c.dll {install}/lib/
+      dependencies: []
+      install_paths:
+        license/libjson_c:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_STATIC_LIBS=ON \
+            -D BUILD_SHARED_LIBS=OFF \
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
       dependencies: []
       install_paths:
         license/libjson_c:

--- a/recipes/libmspack-0.yaml
+++ b/recipes/libmspack-0.yaml
@@ -193,7 +193,51 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          cd libmspack
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}"
+        make: |
+          cd libmspack
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd libmspack
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      install_paths:
+        license/libmspack:
+          - libmspack/COPYING.LIB
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
+      build_script:
+        configure: |
+          cd libmspack
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}"
+        make: |
+          cd libmspack
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd libmspack
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      install_paths:
+        license/libmspack:
+          - libmspack/COPYING.LIB
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
       build_script:
         configure: |
           cd libmspack

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -259,7 +259,6 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
-            -D BUILD_SHARED_LIBS=ON \
             -D OPENSSL_ROOT_DIR="{install}" \
             -D OPENSSL_INCLUDE_DIRS="{includes}" \
             -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
@@ -273,6 +272,38 @@ platforms:
           cd build
           CALL cmake.exe --build . --config Release --target install
           mv {install}/bin/nghttp2.dll {install}/lib/
+      dependencies:
+        - libopenssl>=1.0.1
+        - libz>=1.2.3
+      install_paths:
+        license/libnghttp2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D OPENSSL_ROOT_DIR="{install}" \
+            -D OPENSSL_INCLUDE_DIRS="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ZLIB_ROOT="{includes}" \
+            -D ZLIB_LIBRARY="{libs}/zlibstatic.lib" \
+            -D ENABLE_LIB_ONLY=ON \
+            -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -D ENABLE_STATIC_LIB=ON \
+            -D ENABLE_SHARED_LIB=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
       dependencies:
         - libopenssl>=1.0.1
         - libz>=1.2.3
@@ -303,6 +334,38 @@ platforms:
           cd build
           CALL cmake.exe --build . --config Release --target install
           mv {install}/bin/nghttp2.dll {install}/lib/
+      dependencies:
+        - libopenssl>=1.0.1
+        - libz>=1.2.3
+      install_paths:
+        license/libnghttp2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D OPENSSL_ROOT_DIR="{install}" \
+            -D OPENSSL_INCLUDE_DIR="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ZLIB_ROOT="{includes}" \
+            -D ZLIB_LIBRARY="{libs}/zlibstatic.lib" \
+            -D ENABLE_LIB_ONLY=ON \
+            -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
+            -D ENABLE_STATIC_LIB=ON \
+            -D ENABLE_SHARED_LIB=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
       dependencies:
         - libopenssl>=1.0.1
         - libz>=1.2.3

--- a/recipes/libopenssl-1.1.yaml
+++ b/recipes/libopenssl-1.1.yaml
@@ -222,6 +222,30 @@ platforms:
         - nasm
         - perl
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          CALL set PATH={libs};%PATH%
+          CALL vcvarsall.bat amd64
+          CALL perl Configure no-shared VC-WIN64A zlib --with-zlib-include="{includes}" --with-zlib-lib="{libs}/zlibstatic.lib"
+        make: |
+          CALL set PATH={libs};%PATH%
+          CALL vcvarsall.bat amd64
+          CALL nmake
+      dependencies:
+        - libz
+      install_paths:
+        include:
+          - include/openssl
+        lib:
+          - libssl.lib
+          - libcrypto.lib
+        license/libopenssl:
+          - LICENSE
+      required_tools:
+        - nasm
+        - perl
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -241,6 +265,30 @@ platforms:
           - libssl-1_1.dll
           - libssl.lib
           - libcrypto-1_1.dll
+          - libcrypto.lib
+        license/libopenssl:
+          - LICENSE
+      required_tools:
+        - nasm
+        - perl
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          CALL set PATH={libs};%PATH%
+          CALL vcvarsall.bat x86
+          CALL perl Configure no-shared VC-WIN32 zlib --with-zlib-include="{includes}" --with-zlib-lib="{libs}/zlibstatic.lib"
+        make: |
+          CALL set PATH={libs};%PATH%
+          CALL vcvarsall.bat x86
+          CALL nmake
+      dependencies:
+        - libz
+      install_paths:
+        include:
+          - include/openssl
+        lib:
+          - libssl.lib
           - libcrypto.lib
         license/libopenssl:
           - LICENSE

--- a/recipes/libpcre2-10.yaml
+++ b/recipes/libpcre2-10.yaml
@@ -170,6 +170,33 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D BZIP2_INCLUDE_DIR="{includes}" \
+            -D BZIP2_LIBRARY_RELEASE="{libs}/bz2_static.lib"
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies:
+        - libbz2
+        - libz
+      install_paths:
+        license/libpcre2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -191,6 +218,33 @@ platforms:
           mv {install}/bin/pcre2-8.dll {install}/lib/
       dependencies:
         - libbz2<1.1.0
+        - libz
+      install_paths:
+        license/libpcre2:
+          - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D BZIP2_INCLUDE_DIR="{includes}" \
+            -D BZIP2_LIBRARY_RELEASE="{libs}/bz2_static.lib"
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies:
+        - libbz2
         - libz
       install_paths:
         license/libpcre2:

--- a/recipes/libssh2-1.9.yaml
+++ b/recipes/libssh2-1.9.yaml
@@ -271,6 +271,38 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D CRYPTO_BACKEND=OpenSSL\
+            -D BUILD_SHARED_LIBS=OFF \
+            -D OPENSSL_INCLUDE_DIR="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ENABLE_ZLIB_COMPRESSION=ON \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D BUILD_TESTING=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies:
+        - libopenssl>=1.1.0
+        - libz
+      install_paths:
+        license/libssh2:
+          - COPYING
+      patches: libssh2-1.9-patches
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -302,6 +334,38 @@ platforms:
       install_paths:
         license/libssh2:
           - COPYING
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D CRYPTO_BACKEND=OpenSSL\
+            -D BUILD_SHARED_LIBS=OFF \
+            -D OPENSSL_INCLUDE_DIR="{includes}" \
+            -D LIB_EAY_RELEASE="{libs}/libcrypto.lib" \
+            -D SSL_EAY_RELEASE="{libs}/libssl.lib" \
+            -D ENABLE_ZLIB_COMPRESSION=ON \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D BUILD_TESTING=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+      dependencies:
+        - libopenssl>=1.1.0
+        - libz
+      install_paths:
+        license/libssh2:
+          - COPYING
+      patches: libssh2-1.9-patches
       required_tools:
         - cmake
         - visualstudio>=2017

--- a/recipes/libxml2-2.9.yaml
+++ b/recipes/libxml2-2.9.yaml
@@ -240,6 +240,34 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D LIBXML2_WITH_LZMA=OFF \
+            -D LIBXML2_WITH_ICONV=OFF \
+            -D LIBXML2_WITH_PYTHON=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+          mv {install}/include/libxml2/libxml {install}/include/libxml
+      dependencies:
+        - libz
+      install_paths:
+        license/libxml2:
+          - Copyright
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -261,6 +289,34 @@ platforms:
           CALL cmake.exe --build . --config Release --target install
           mv {install}/include/libxml2/libxml {install}/include/libxml
           mv {install}/bin/libxml2.dll {install}/lib/
+      dependencies:
+        - libz
+      install_paths:
+        license/libxml2:
+          - Copyright
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_SHARED_LIBS=OFF \
+            -D ZLIB_INCLUDE_DIR="{includes}" \
+            -D ZLIB_LIBRARY_RELEASE="{libs}/zlibstatic.lib" \
+            -D LIBXML2_WITH_LZMA=OFF \
+            -D LIBXML2_WITH_ICONV=OFF \
+            -D LIBXML2_WITH_PYTHON=OFF
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+          mv {install}/include/libxml2/libxml {install}/include/libxml
       dependencies:
         - libz
       install_paths:

--- a/recipes/libz-1.2.11.yaml
+++ b/recipes/libz-1.2.11.yaml
@@ -179,6 +179,28 @@ platforms:
       required_tools:
         - cmake
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D CMAKE_POSITION_INDEPENDENT_CODE=ON
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
+          mv {install}/bin/zlib.dll {install}/lib/
+      dependencies: []
+      install_paths:
+        license/zlib:
+          - README
+      required_tools:
+        - cmake
+        - visualstudio>=2017
     x86:
       build_script:
         configure: |
@@ -192,7 +214,27 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
-          mv {install}/bin/zlib.dll {install}/lib/
+      dependencies: []
+      install_paths:
+        license/libz:
+          - README
+      required_tools:
+        - cmake
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        configure: |
+          mkdir build
+          cd build
+          CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
+            -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D CMAKE_POSITION_INDEPENDENT_CODE=ON
+        make: |
+          cd build
+          CALL cmake.exe --build . --config Release
+        install: |
+          cd build
+          CALL cmake.exe --build . --config Release --target install
       dependencies: []
       install_paths:
         license/libz:

--- a/recipes/pdcurses-3.9.yaml
+++ b/recipes/pdcurses-3.9.yaml
@@ -37,6 +37,23 @@ platforms:
       patches: pdcurses-3.9-patches
       required_tools:
         - visualstudio
+    x64-static:
+      build_script:
+        make: |
+          CD wincon
+          CALL vcvarsall.bat amd64
+          CALL nmake -f Makefile.vc WIDE=Y DLL=N
+      dependencies: []
+      install_paths:
+        include:
+          - curses.h
+        lib:
+          - wincon/pdcurses.lib
+        license/pdcurses:
+          - README.md
+      patches: pdcurses-3.9-patches
+      required_tools:
+        - visualstudio
     x86:
       build_script:
         make: |
@@ -49,6 +66,23 @@ platforms:
           - curses.h
         lib:
           - wincon/pdcurses.dll
+          - wincon/pdcurses.lib
+        license/pdcurses:
+          - README.md
+      patches: pdcurses-3.9-patches
+      required_tools:
+        - visualstudio
+    x86-static:
+      build_script:
+        make: |
+          CD wincon
+          CALL vcvarsall.bat x86
+          CALL nmake -f Makefile.vc WIDE=Y DLL=N
+      dependencies: []
+      install_paths:
+        include:
+          - curses.h
+        lib:
           - wincon/pdcurses.lib
         license/pdcurses:
           - README.md

--- a/recipes/pthreads-win32-2.9.yaml
+++ b/recipes/pthreads-win32-2.9.yaml
@@ -37,6 +37,23 @@ platforms:
       patches: pthreads-2.9.1-patches
       required_tools:
         - visualstudio>=2017
+    x64-static:
+      build_script:
+        make: |
+          CALL vcvarsall.bat amd64
+          CALL nmake realclean VC-static
+      dependencies: []
+      install_paths:
+        include:
+          - pthread.h
+          - sched.h
+        lib:
+          - pthreadVC2.lib
+        license/pthreads_win32:
+          - COPYING*
+      patches: pthreads-2.9.1-patches
+      required_tools:
+        - visualstudio>=2017
     x86:
       build_script:
         make: |
@@ -49,6 +66,23 @@ platforms:
           - sched.h
         lib:
           - pthreadVC2.dll
+          - pthreadVC2.lib
+        license/pthreads_win32:
+          - COPYING*
+      patches: pthreads-2.9.1-patches
+      required_tools:
+        - visualstudio>=2017
+    x86-static:
+      build_script:
+        make: |
+          CALL vcvarsall.bat x86
+          CALL nmake realclean VC-static
+      dependencies: []
+      install_paths:
+        include:
+          - pthread.h
+          - sched.h
+        lib:
           - pthreadVC2.lib
         license/pthreads_win32:
           - COPYING*


### PR DESCRIPTION
Static variants for Windows for clamav dependencies. 

Note: I had to disable nghttp2 support in libcurl because the static build fails on Windows when it is enabled. Works fine on Linux/FreeBSD/Mac. 🤷‍♀️