### PR TITLE
update to zlib-1.2.12

### DIFF
--- a/recipes/libz-1.2.12.yaml
+++ b/recipes/libz-1.2.12.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libz
-version: "1.2.11"
-url: https://www.zlib.net/zlib-1.2.11.tar.gz
+version: "1.2.12"
+url: https://www.zlib.net/zlib-1.2.12.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
update to zlib-1.2.12

https://www.zlib.net/zlib-1.2.11.tar.gz is no longer available for download.