### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/collections/clamav_deps-0.105.yaml
+++ b/collections/clamav_deps-0.105.yaml
@@ -1,0 +1,109 @@
+# Copyright (C) 2020 Cisco Systems, Inc. and/or its affiliates. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: clamav_deps
+version: "0.105"
+mussels_version: "0.2"
+type: collection
+platforms:
+  Linux:
+    host:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2<1.1.0
+    host-static:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - libcheck
+        - ncurses
+  Freebsd:
+    host:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2<1.1.0
+    host-static:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - libcheck
+        - ncurses
+  Darwin:
+    host:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - libcheck
+        - ncurses
+    host-static:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2
+        - libcheck
+        - ncurses
+  Windows:
+    x64:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - pthreads_win32
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2<1.1.0
+        - pdcurses
+        - libcheck
+    x86:
+      dependencies:
+        - libz
+        - libcurl
+        - libjson_c
+        - pthreads_win32
+        - libxml2
+        - libopenssl
+        - libpcre2
+        - libbz2<1.1.0
+        - pdcurses
+        - libcheck

--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "7.82.0"
-url: https://curl.se/download/curl-7.82.0.zip
+version: "7.83.0"
+url: https://curl.se/download/curl-7.83.0.zip
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libjson-c-0.15.yaml
+++ b/recipes/libjson-c-0.15.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libjson_c
-version: "0.15.0"
-url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.15.tar.gz
+version: "0.16.0"
+url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.16.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libpcre2-10.yaml
+++ b/recipes/libpcre2-10.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libpcre2
-version: "10.39"
-url: https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-10.39.tar.gz
+version: "10.40"
+url: https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/pdcurses-3.9.yaml
+++ b/recipes/pdcurses-3.9.yaml
@@ -14,7 +14,10 @@
 
 name: pdcurses
 version: "3.9"
-url: https://versaweb.dl.sourceforge.net/project/pdcurses/pdcurses/3.9/PDCurses-3.9.tar.gz
+url: https://github.com/wmcbrine/PDCurses/archive/refs/tags/3.9.tar.gz
+archive_name_change:
+  - "3.9"
+  - "PDCurses-3.9"
 mussels_version: "0.2"
 type: recipe
 platforms:


### PR DESCRIPTION
Note: pdcurses is on github now, and pcre2 has a new org