### PR TITLE
Bump version sfor curl, nghttp2, libopenssl, and libxml2

### DIFF
--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "7.83.0"
-url: https://curl.se/download/curl-7.83.0.zip
+version: "7.84.0"
+url: https://curl.se/download/curl-7.84.0.zip
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libnghttp2
-version: "1.47.0"
-url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.47.0.zip
+version: "1.48.0"
+url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.48.0.zip
 archive_name_change:
   - v
   - nghttp2-

--- a/recipes/libopenssl-1.1.yaml
+++ b/recipes/libopenssl-1.1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libopenssl
-version: "1.1.1n"
-url: https://www.openssl.org/source/openssl-1.1.1n.tar.gz
+version: "1.1.1q"
+url: https://www.openssl.org/source/openssl-1.1.1q.tar.gz
 mussels_version: "0.2"
 type: recipe
 platforms:

--- a/recipes/libxml2-2.9.yaml
+++ b/recipes/libxml2-2.9.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libxml2
-version: "2.9.13"
-url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.13/libxml2-v2.9.13.tar.gz
+version: "2.9.14"
+url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.9.14/libxml2-v2.9.14.tar.gz
 #url: http://xmlsoft.org/sources/libxml2-2.9.12.tar.gz
 # 2.9.12 build broken on Windows due to packaging issue, fixed by this commit:
 #   https://gitlab.gnome.org/GNOME/libxml2/-/commit/7d4060d252354a8d650a3c50256fe3679a40691d


### PR DESCRIPTION
libcurl 7.83.0 -> 7.84.0
nghttp2 1.47.0 -> 1.48.0
openssl 1.1.1n -> 1.1.1q
libxml2 2.9.13 -> 2.9.14