### PR TITLE
openssl and curl updates

### DIFF
--- a/recipes/libcurl-7.yaml
+++ b/recipes/libcurl-7.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "7.85.0"
-url: https://curl.se/download/curl-7.85.0.zip
+version: "7.86.0"
+url: https://curl.se/download/curl-7.86.0.zip
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libopenssl-1.1.yaml
+++ b/recipes/libopenssl-1.1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libopenssl
-version: "1.1.1q"
-url: https://www.openssl.org/source/openssl-1.1.1q.tar.gz
+version: "1.1.1s"
+url: https://www.openssl.org/source/openssl-1.1.1s.tar.gz
 mussels_version: "0.2"
 type: recipe
 platforms:


### PR DESCRIPTION
Bump openssl from 1.1.1q to 1.1.1s
Bump curl version from 7.85 to 7.86