### PR TITLE
Freebsd: patchelf issues

### DIFF
--- a/recipes/libssh2-1.10.yaml
+++ b/recipes/libssh2-1.10.yaml
@@ -115,7 +115,7 @@ platforms:
         install: |
           cd build
           gmake install
-          install_name_tool -add_rpath @executable_path/../lib "{install}/lib/libssh2.dylib"
+          patchelf --set-rpath '$ORIGIN/../lib' "{install}/lib/libssh2.so"
       dependencies:
         - libopenssl>=3.0
         - libz

--- a/tools/patchelf.yaml
+++ b/tools/patchelf.yaml
@@ -28,3 +28,14 @@ platforms:
         - /usr/local/bin/patchelf
       usr:
         - /usr/bin/patchelf
+  Freebsd:
+    path_checks:
+      - patchelf
+    command_checks:
+      - command: "patchelf --version"
+        output_has: "patchelf"
+    file_checks:
+      local:
+        - /usr/local/bin/patchelf
+      usr:
+        - /usr/bin/patchelf


### PR DESCRIPTION
One recipe had copypaste issue from Darwin instructions.

Some recipes require patchelf, but no patchelf tool defiend for Freebsd.