### PR TITLE
Revert libjson-c recipe to 0.16 (temporarily)

### DIFF
--- a/recipes/libjson-c-0.16.yaml
+++ b/recipes/libjson-c-0.16.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libjson_c
-version: "0.17.0"
-url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.17.tar.gz
+version: "0.16.0"
+url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.16.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
There is a compatibility issue in clamav on Windows with libjson-c 0.17 around the definition of ssize_t. For the sake of the patch versions that we're publishing tomorrow, we're going to temporarily revert to 0.16. Then fix the issue and bump back to 0.17.