### PR TITLE
Revert "Revert libjson-c recipe to 0.16 (temporarily)"

### DIFF
--- a/recipes/libjson-c-0.16.yaml
+++ b/recipes/libjson-c-0.16.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libjson_c
-version: "0.16.0"
-url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.16.tar.gz
+version: "0.17.0"
+url: https://s3.amazonaws.com/json-c_releases/releases/json-c-0.17.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
This reverts commit 3f7f88077402adde5614433544035e3bc661ac08. That is, this bumps libjson-c recipe to 0.17 (again).

This PR is pending backports of https://github.com/Cisco-Talos/clamav/pull/1002 for 1.1, 1.0, and 0.103.