### PR TITLE
Bump libcurl, libnghttp2, openssl, and zlib versions

### DIFF
--- a/recipes/libcurl-8.yaml
+++ b/recipes/libcurl-8.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "8.2.1"
-url: https://curl.se/download/curl-8.2.1.zip
+version: "8.4.0"
+url: https://curl.se/download/curl-8.4.0.zip
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libnghttp2
-version: "1.55.1"
-url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.55.1.zip
+version: "1.57.0"
+url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.57.0.zip
 archive_name_change:
   - v
   - nghttp2-

--- a/recipes/libopenssl-3.1.yaml
+++ b/recipes/libopenssl-3.1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libopenssl
-version: "3.1.2"
-url: https://www.openssl.org/source/openssl-3.1.2.tar.gz
+version: "3.1.3"
+url: https://www.openssl.org/source/openssl-3.1.3.tar.gz
 mussels_version: "0.2"
 type: recipe
 platforms:

--- a/recipes/libz-1.3.yaml
+++ b/recipes/libz-1.3.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libz
-version: "1.2.13"
-url: https://github.com/madler/zlib/releases/download/v1.2.13/zlib-1.2.13.tar.gz
+version: "1.3"
+url: https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
libcurl 8.4.0

libnghttp2 1.57.0

openssl 3.1.3

zlib 1.3