### PR TITLE
Update recipes ahead of ClamAV 1.3.0 release

### DIFF
--- a/recipes/libcurl-8.yaml
+++ b/recipes/libcurl-8.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libcurl
-version: "8.5.0"
-url: https://curl.se/download/curl-8.5.0.zip
+version: "8.6.0"
+url: https://curl.se/download/curl-8.6.0.zip
 mussels_version: "0.3"
 type: recipe
 platforms:

--- a/recipes/libcurl-8.yaml
+++ b/recipes/libcurl-8.yaml
@@ -27,6 +27,7 @@ platforms:
           cmake .. \
             -G Xcode \
             -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -69,6 +70,7 @@ platforms:
           cmake .. \
             -G Xcode \
             -D CMAKE_OSX_ARCHITECTURES="arm64;x86_64" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -111,6 +113,7 @@ platforms:
           cd build
           cmake .. \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -152,6 +155,7 @@ platforms:
           cd build
           cmake .. \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -194,6 +198,7 @@ platforms:
           cd build
           cmake .. \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -236,6 +241,7 @@ platforms:
           cd build
           cmake .. \
             -D CMAKE_BUILD_TYPE=Release \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D CMAKE_POSITION_INDEPENDENT_CODE=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -279,6 +285,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A ARM \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -317,6 +324,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A ARM64 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -355,6 +363,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -393,6 +402,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -431,6 +441,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A ARM \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -469,6 +480,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A ARM64 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -507,6 +519,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A x64 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \
@@ -545,6 +558,7 @@ platforms:
           cd build
           CALL cmake.exe .. -G "{visualstudio.cmake_generator}" -A Win32 \
             -D CMAKE_INSTALL_PREFIX="{install}" \
+            -D BUILD_LIBCURL_DOCS=OFF \
             -D BUILD_SHARED_LIBS=ON \
             -D CURL_USE_OPENSSL=ON \
             -D OPENSSL_INCLUDE_DIR="{includes}" \

--- a/recipes/libnghttp2-1.yaml
+++ b/recipes/libnghttp2-1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libnghttp2
-version: "1.58.0"
-url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.58.0.zip
+version: "1.59.0"
+url: https://github.com/nghttp2/nghttp2/archive/refs/tags/v1.59.0.zip
 archive_name_change:
   - v
   - nghttp2-

--- a/recipes/libopenssl-3.1.yaml
+++ b/recipes/libopenssl-3.1.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libopenssl
-version: "3.2.0"
-url: https://www.openssl.org/source/openssl-3.2.0.tar.gz
+version: "3.2.1"
+url: https://www.openssl.org/source/openssl-3.2.1.tar.gz
 mussels_version: "0.2"
 type: recipe
 platforms:

--- a/recipes/libz-1.3.yaml
+++ b/recipes/libz-1.3.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 name: libz
-version: "1.3"
-url: https://github.com/madler/zlib/releases/download/v1.3/zlib-1.3.tar.gz
+version: "1.3.1"
+url: https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
libcurl 8.5.0 -> 8.6.0

libnghttp2 1.58.0 -> 1.59.0

openssl 3.2.0 -> 3.2.1

libz 1.3 -> 1.3.1