### PR TITLE
ncurses: also build libtinfo

### DIFF
--- a/recipes/ncurses-6.yaml
+++ b/recipes/ncurses-6.yaml
@@ -22,7 +22,7 @@ platforms:
     host:
       build_script:
         configure: |
-          CFLAGS="-arch x86_64 -arch arm64" ./configure --prefix={install}
+          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --prefix={install}
         make: |
           make
         install: |
@@ -37,7 +37,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          CFLAGS="-arch x86_64 -arch arm64" ./configure --prefix={install}
+          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --prefix={install}
         make: |
           make
         install: |
@@ -53,7 +53,7 @@ platforms:
     host:
       build_script:
         configure: |
-          ./configure --prefix={install}
+          ./configure --with-termlib --prefix={install}
         make: |
           gmake
         install: |
@@ -68,7 +68,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          ./configure --prefix={install}
+          ./configure --with-termlib --prefix={install}
         make: |
           gmake
         install: |
@@ -84,7 +84,7 @@ platforms:
     host:
       build_script:
         configure: |
-          ./configure --prefix={install}
+          ./configure --with-termlib --prefix={install}
         make: |
           make
         install: |
@@ -99,7 +99,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          ./configure --prefix={install}
+          ./configure --with-termlib --prefix={install}
         make: |
           make
         install: |


### PR DESCRIPTION
Building with ncurses is adding a dependency on libtinfo although we're not building/installing libtinfo!!

When doing a clamav build with static dependencies, that ends up depending on a SHARED libtinfo from the host instead of building in our own static libtinfo librar!!!

That looks like this in the clamav CMake configuration summary:
```
-- Application Extra Dependencies --
        GUI support:
            ncurses         /usr/include
                            /home/micah/.mussels/install/host-static/lib/libncurses.a;/usr/lib/x86_64-linux-gnu/libtinfo.so
```

That means that clamdtop will not work without libtinfo installed (somehow), or may not work at all if the expected path does not match the way it is installed on the host.

This commit enables building/installing libtinfo.a or .so for ncurses builds.