### PR TITLE
Revert ncurses to disable widechar support

### DIFF
--- a/recipes/ncurses-6.yaml
+++ b/recipes/ncurses-6.yaml
@@ -22,7 +22,7 @@ platforms:
     host:
       build_script:
         configure: |
-          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --prefix={install}
+          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           make
         install: |
@@ -37,7 +37,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --prefix={install}
+          CFLAGS="-arch x86_64 -arch arm64" ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           make
         install: |
@@ -53,7 +53,7 @@ platforms:
     host:
       build_script:
         configure: |
-          ./configure --with-termlib --prefix={install}
+          ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           gmake
         install: |
@@ -68,7 +68,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          ./configure --with-termlib --prefix={install}
+          ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           gmake
         install: |
@@ -84,7 +84,7 @@ platforms:
     host:
       build_script:
         configure: |
-          ./configure --with-termlib --prefix={install}
+          ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           make
         install: |
@@ -99,7 +99,7 @@ platforms:
     host-static:
       build_script:
         configure: |
-          ./configure --with-termlib --prefix={install}
+          ./configure --with-termlib --disable-widec --prefix={install}
         make: |
           make
         install: |


### PR DESCRIPTION
Turns out ncurses 6.4 default was to build libncurses.a.  ncurses 6.5 default is to build libncursesw.a, which also installs different headers in prefix/ncursesw/ subdirectory.  Aka not compatible.

The other option is for us to go modify clamav source to support ncursesw, which is obviously not as simple.  Right now we need this change to fix the build.