### PR TITLE
libxml2: revert from 2.13.3 to 2.12.8 because of C99 compatibility issues

### DIFF
--- a/recipes/libxml2-2.10.yaml
+++ b/recipes/libxml2-2.10.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 name: libxml2
-version: "2.13.3"
-url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.13.3/libxml2-v2.13.3.tar.gz
+version: "2.12.8"
+url: https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.12.8/libxml2-v2.12.8.tar.gz
 archive_name_change:
   - libxml2-v2.13.0-cdd2575f7fbab1d8162600f4048bc37503c80e28
-  - libxml2-v2.13.3
+  - libxml2-v2.12.8
 mussels_version: "0.3"
 type: recipe
 platforms:


### PR DESCRIPTION
Build fails on macOS using Xcode:

/Users/clamav_jenkins_svc/.mussels/cache/work/host-static/libxml2-v2.13.3/dict.c:970:17: error: implicit declaration of function 'getentropy' is invalid in C99 [-Werror,-Wimplicit-function-declaration]

It looks like all known CVEs are fixed in 2.12.8.
Homebrew is still on 2.12.8 as well.