### PR TITLE
libcurl, Windows: disable libidn2 disable pkg-config

### DIFF
--- a/recipes/libcurl-8.yaml
+++ b/recipes/libcurl-8.yaml
@@ -298,7 +298,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Release
@@ -337,7 +339,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Release
@@ -376,7 +380,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Release
@@ -415,7 +421,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Release
@@ -454,7 +462,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Debug
@@ -493,7 +503,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Debug
@@ -532,7 +544,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Debug
@@ -571,7 +585,9 @@ platforms:
             -D USE_NGHTTP2=ON \
             -D NGHTTP2_INCLUDE_DIR="{includes}" \
             -D NGHTTP2_LIBRARY="{libs}/nghttp2.lib" \
-            -D BUILD_CURL_EXE=OFF
+            -D BUILD_CURL_EXE=OFF \
+            -D USE_LIBIDN2=OFF \
+            -D PKG_CONFIG_EXECUTABLE=none
         make: |
           cd build
           CALL cmake.exe --build . --config Debug


### PR DESCRIPTION
Curl has an option to use libidn2 in version 8.9.0.

Pkg-config may unexpectedly find it and use it.

I encountered this on Windows because libidn2 was installed by Strawberry Perl, under C:\Strawberry. Pkg-config found that and tried to build it into Curl, which is problematic in part because we don't want to include or ship libidn2 with our software.

But also problematic because libidn2 provided by Strawberry Perl used a different OpenSSL incompatible with the one we're compiling against.

This commit explicitly disables pkg-config and libidn2 for libcurl builds.
TODO: Perhaps disable pkg-config for all recipes and all platforms? Mussels builds should only draw from other mussels include/lib files.