### PR TITLE
Revert change to move checkDynamic.dll from bin to lib

### DIFF
--- a/recipes/libcheck-0.15.yaml
+++ b/recipes/libcheck-0.15.yaml
@@ -172,6 +172,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -191,6 +192,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -210,6 +212,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -229,6 +232,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Release --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -248,6 +252,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Debug --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -267,6 +272,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Debug --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -286,6 +292,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Debug --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER
@@ -305,6 +312,7 @@ platforms:
         install: |
           cd build
           CALL cmake.exe --build . --config Debug --target install
+          mv "{install}/bin/checkDynamic.dll" "{install}/lib/"
       install_paths:
         license/libcheck:
           - COPYING.LESSER


### PR DESCRIPTION
This change is in fact required for the Jenkins clamav build.

I'm not sure why it can't find it in the bin directory, but I'm in a hurry.