### PR TITLE
Patch json-c 0.19 object cleanup regressions

### DIFF
--- a/recipes/json-c-patches/json-c-0.19-object-cleanup-fixes.patch
+++ b/recipes/json-c-patches/json-c-0.19-object-cleanup-fixes.patch
@@ -1,0 +1,265 @@
+From 49df1e55f43a368d87b10556e8047976bf07833a Mon Sep 17 00:00:00 2001
+From: Valerie Snyder <valsnyde@cisco.com>
+Date: Tue, 11 Aug 2026 22:24:05 -0400
+Subject: [PATCH] Backport json-c 0.19 object cleanup fixes
+
+Combine the upstream fixes for json_object_put() cleanup, userdata callback
+state, and freed-object return values into one patch.
+
+Upstream commits:
+
+f291fa81c6f21d925ea771a8cca597f5886309cc
+3aa996b5b6bd96c29f2c6da98da33c3fb3d13038
+0c3a5a1994ed6b5957d2e878fc1298ce9aa09b3f
+69be99ef8e99d811d7810bdf75864ae800a67e50
+---
+ json_object.c                    | 58 +++++++++++++++++++++++--------
+ json_object.h                    |  4 +--
+ tests/test_deep_nesting.c        | 59 ++++++++++++++++++++++++++++++++
+ tests/test_deep_nesting.expected |  8 +++++
+ 4 files changed, 113 insertions(+), 16 deletions(-)
+
+diff --git json-c-0.19.orig/json_object.c json-c-0.19/json_object.c
+index 0a61967..6212608 100644
+--- json-c-0.19.orig/json_object.c
++++ json-c-0.19/json_object.c
+@@ -273,13 +273,31 @@ struct json_object *json_object_get(struct json_object *jso)
+ }
+ 
+ 
++/**
++  * Return values for _json_object_put_maybe_free().
++  * json_object_put_still_refd and json_object_put_freed match the documented
++  * return values of json_object_put(), so they can be returned directly.
++  */
++enum json_object_put_result
++{
++	json_object_put_still_refd = 0, /* refcount decremented, object not freed */
++	json_object_put_freed = 1,      /* refcount reached zero, memory released */
++	json_object_put_container = 2   /* refcount reached zero, but the object is a
++	                                   non-empty container: the caller must free
++	                                   the contents, then the object itself */
++};
++
+ /**
+   * Internal json_object_put function
+-  * Returns 0 if we're done "freeing" the object, either because its memory
+-  * was actually released, or we just needed to decrement the refcount.
+-  * Returns 1 when the object is a non-empty container that still needs to be handled.
++  * Returns json_object_put_still_refd if a reference remains, and the object
++  * was not freed.
++  * Returns json_object_put_freed if the object's memory was released, either
++  * because it holds no other objects, or because free_containers was set.
++  * Returns json_object_put_container when the refcount reached zero but the
++  * object is a non-empty container; the caller must free the contents, then
++  * call this function again with free_containers set to free the object itself.
+   */
+-static inline int _json_object_put_maybe_free(struct json_object *jso, int free_containers)
++static inline enum json_object_put_result _json_object_put_maybe_free(struct json_object *jso, int free_containers)
+ {
+ 	/* Avoid invalid free and crash explicitly instead of (silently)
+ 	 * segfaulting.
+@@ -298,11 +316,14 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
+ 	if (--jso->_ref_count > 0)
+ #endif
+ 	{
+-		return 0;  // All done, caller doesn't need to do anything else
++		return json_object_put_still_refd;
+ 	}
+ 
+ 	if (jso->_user_delete)
+ 		jso->_user_delete(jso, jso->_userdata);
++	jso->_user_delete = NULL;
++	jso->_userdata = NULL; // aka _delete_parent, but json_object_put() will
++	                       // have already grabbed it if it needs it.
+ 
+ 	switch (jso->o_type)
+ 	{
+@@ -312,15 +333,15 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
+ 			json_object_object_delete(jso);
+ 			break;
+ 		}
+-		return 1;
+-	case json_type_array: 
++		return json_object_put_container;
++	case json_type_array:
+ 		// container objects are handled by the caller
+ 		if (free_containers || array_list_length(JC_ARRAY(jso)->c_array) == 0)
+ 		{
+ 			json_object_array_delete(jso);
+ 			break;
+ 		}
+-		return 1;
++		return json_object_put_container;
+ 	case json_type_string:
+ 		json_object_string_delete(jso);
+ 		break;
+@@ -328,16 +349,19 @@ static inline int _json_object_put_maybe_free(struct json_object *jso, int free_
+ 		json_object_generic_delete(jso);
+ 		break;
+ 	}
+-	return 0;  // All done, caller doesn't need to do anything else
++	return json_object_put_freed;
+ }
+ 
+ int json_object_put(struct json_object *jso)
+ {
++	enum json_object_put_result rc;
++
+ 	if (!jso)
+ 		return 0;
+ 
+-	if (_json_object_put_maybe_free(jso, 0) == 0)
+-		return 0;
++	rc = _json_object_put_maybe_free(jso, 0);
++	if (rc != json_object_put_container)
++		return (int)rc;
+ 	// else, it's a non-empty container object, handle it below
+ 
+ 	// Note: jso is now a "zombie" object, _ref_count == 0 but memory not yet released
+@@ -396,7 +420,7 @@ int json_object_put(struct json_object *jso)
+ 			}
+ 
+ 			// Now, handle actually freeing the json_object in that slot
+-			if (!child || _json_object_put_maybe_free(child, 0) == 0)
++			if (!child || _json_object_put_maybe_free(child, 0) != json_object_put_container)
+ 			{
+  				// child is either freed, or still referenced somewhere else
+ 				// leave it as-is and handle the previous slot
+@@ -434,12 +458,18 @@ int json_object_put(struct json_object *jso)
+ 
+ 		// All slots are cleared, now pop back up to the parent
+ 		{
+-			json_object *parent = jso->_delete_parent;
+ 			// jso is a child that's already been detached from its parent
+ 			// so we need to actually free it now
++			// Be sure to grab _delete_parent *before* freeing jso.
++			json_object *parent = jso->_delete_parent;
++			enum json_object_put_result rc;
+ 			assert(jso->_ref_count == 0);
+ 			jso->_ref_count++;   // We're the exclusive owner of jso, non-atomic add is ok.
+-			assert(_json_object_put_maybe_free(jso, 1) == 0);
++			// Note: the call must not be inside assert(), or it gets
++			// compiled out when NDEBUG is defined and the memory leaks.
++			rc = _json_object_put_maybe_free(jso, 1);
++			assert(rc == json_object_put_freed);
++			(void)rc;
+ 			jso = parent;
+ 			// iteration will be reset at the top of the loop
+ 		}
+diff --git json-c-0.19.orig/json_object.h json-c-0.19/json_object.h
+index e21138e..7edb63d 100644
+--- json-c-0.19.orig/json_object.h
++++ json-c-0.19/json_object.h
+@@ -259,7 +259,7 @@ JSON_EXPORT void *json_object_get_userdata(json_object *jso);
+  * The user_delete parameter is optional and may be passed as NULL, even if
+  * the userdata parameter is non-NULL.  It will be called just before the
+  * json_object is deleted, after it's reference count goes to zero
+- * (see json_object_put()).
++ * (see json_object_put()) but before any child objects are freed.
+  * If this is not provided, it is up to the caller to free the userdata at
+  * an appropriate time. (i.e. after the json_object is deleted)
+  *
+@@ -293,7 +293,7 @@ JSON_EXPORT void json_object_set_userdata(json_object *jso, void *userdata,
+  * The user_delete parameter is optional and may be passed as NULL, even if
+  * the userdata parameter is non-NULL.  It will be called just before the
+  * json_object is deleted, after it's reference count goes to zero
+- * (see json_object_put()).
++ * (see json_object_put()) but before any child objects are freed.
+  * If this is not provided, it is up to the caller to free the userdata at
+  * an appropriate time. (i.e. after the json_object is deleted)
+  *
+diff --git json-c-0.19.orig/tests/test_deep_nesting.c json-c-0.19/tests/test_deep_nesting.c
+index 364c482..4bf2457 100644
+--- json-c-0.19.orig/tests/test_deep_nesting.c
++++ json-c-0.19/tests/test_deep_nesting.c
+@@ -56,6 +56,61 @@ static void test_deep_nesting_tostring(const char *str)
+ 	json_tokener_free(tok);
+ }
+ 
++struct userdata_test {
++	int userdata_val;
++	char *p;
++};
++/*
++ * Check that the user_delete function is only called once, even with the
++ * newer code to avoid deeply nested calls during json_object_put().
++ */
++static void user_delete_test(struct json_object *jso, void *userdata_in)
++{
++	struct userdata_test *userdata = (struct userdata_test *)userdata_in;
++	printf("in user_delete, userdata_val=%d\n", userdata->userdata_val);
++	fflush(stdout);
++	userdata->userdata_val = 0;
++	userdata->p[0] = 'x';
++	userdata->p[8191] = 'x';
++	free(userdata->p);
++}
++static void test_nesting_with_user_delete(void)
++{
++	json_object *jso;
++	struct userdata_test userdata_val = {
++		1, malloc(8192)
++	};
++
++	jso = json_object_new_object();
++	json_object_set_userdata(jso, &userdata_val, user_delete_test);
++	json_object_object_add(jso, "somekey", json_object_new_string("foo"));
++	json_object_put(jso);
++}
++
++/*
++ * Check that json_object_put() returns 1 whenever the object is freed,
++ * including for scalars and empty containers, and 0 only when a
++ * reference remains.
++ */
++static void test_put_return_values(void)
++{
++	json_object *jso;
++
++	printf("put(empty object) returned %d\n", json_object_put(json_object_new_object()));
++	printf("put(empty array) returned %d\n", json_object_put(json_object_new_array()));
++	printf("put(string) returned %d\n", json_object_put(json_object_new_string("foo")));
++	printf("put(int) returned %d\n", json_object_put(json_object_new_int(42)));
++
++	jso = json_object_new_object();
++	json_object_object_add(jso, "somekey", json_object_new_string("foo"));
++	printf("put(non-empty object) returned %d\n", json_object_put(jso));
++
++	jso = json_object_new_object();
++	json_object_get(jso);
++	printf("put(still-referenced object) returned %d\n", json_object_put(jso));
++	printf("put(last reference) returned %d\n", json_object_put(jso));
++}
++
+ int main(int argc, char **argv)
+ {
+ 	char *str;	
+@@ -77,5 +132,9 @@ int main(int argc, char **argv)
+ 
+ 	free(str);
+ 
++	test_nesting_with_user_delete();
++
++	test_put_return_values();
++
+ 	return EXIT_SUCCESS;
+ }
+diff --git json-c-0.19.orig/tests/test_deep_nesting.expected json-c-0.19/tests/test_deep_nesting.expected
+index b869cfa..2449ede 100644
+--- json-c-0.19.orig/tests/test_deep_nesting.expected
++++ json-c-0.19/tests/test_deep_nesting.expected
+@@ -1,2 +1,10 @@
+ Parsed depth 100000 string to json_object: yes
+ Freed json_object
++in user_delete, userdata_val=1
++put(empty object) returned 1
++put(empty array) returned 1
++put(string) returned 1
++put(int) returned 1
++put(non-empty object) returned 1
++put(still-referenced object) returned 0
++put(last reference) returned 1
+-- 
+2.50.1 (Apple Git-155)
+

--- a/recipes/libjson-c-0.yaml
+++ b/recipes/libjson-c-0.yaml
@@ -39,6 +39,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - make
         - xcode
@@ -65,6 +66,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - make
         - xcode
@@ -88,6 +90,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - make
         - gcc
@@ -112,6 +115,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - make
         - gcc
@@ -134,6 +138,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - gmake
         - clang
@@ -158,6 +163,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - gmake
         - clang
@@ -180,6 +186,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -201,6 +208,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -222,6 +230,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -243,6 +252,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -264,6 +274,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -285,6 +296,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -306,6 +318,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017
@@ -327,6 +340,7 @@ platforms:
       install_paths:
         license/libjson_c:
           - COPYING
+      patches: json-c-patches
       required_tools:
         - cmake
         - visualstudio>=2017


### PR DESCRIPTION
## Summary

- carry four upstream post-release fixes for json-c 0.19 object cleanup
  regressions in one aggregate patch
- apply the patch to every supported dynamic, static, release, and debug
  target
- avoid dependence on filesystem patch enumeration order
- retain json-c 0.19 while waiting for an upstream maintenance release

## Root cause

json-c 0.19 replaced recursive `json_object_put()` cleanup with an iterative
implementation. The release placed the final container-freeing call inside
`assert()`. Mussels builds release artifacts with `NDEBUG`, so the compiler
removes that call and leaks every non-empty JSON object or array tree.

The same rewrite also introduced duplicate userdata cleanup and stale userdata
handling, and changed the documented `json_object_put()` return values. This PR
carries the four upstream commits that address the complete set of known
cleanup regressions:

- https://github.com/json-c/json-c/commit/f291fa81c6f21d925ea771a8cca597f5886309cc
- https://github.com/json-c/json-c/commit/3aa996b5b6bd96c29f2c6da98da33c3fb3d13038
- https://github.com/json-c/json-c/commit/0c3a5a1994ed6b5957d2e878fc1298ce9aa09b3f
- https://github.com/json-c/json-c/commit/69be99ef8e99d811d7810bdf75864ae800a67e50

The upstream release request and confirmation of the leak are tracked in
https://github.com/json-c/json-c/issues/954.

Mussels currently enumerates patch directories using unsorted `os.listdir()`.
Because these upstream changes are sequentially dependent, separate patch
files worked where the filesystem returned numeric order but failed on macOS
when patch 4 was returned first. Combining the final upstream changes into one
patch makes this cookbook fix independent of directory enumeration order.

## Impact

ClamAV's Valgrind tests began reporting complete metadata trees as definitely
and indirectly lost after the dependency update. Short-lived tools release the
memory at process exit, but persistent consumers that repeatedly create JSON
trees can accumulate memory over time.

No ClamAV source change is required. Rebuilding the dependency artifacts with
this patch restores json-c's expected ownership behavior.

## Validation

- applied the aggregate patch to the pristine 0.19 tarball using Mussels'
  Python patch engine
- confirmed the resulting files are byte-identical to applying all four
  upstream commits in order
- configured and built json-c shared and static Release libraries on macOS
- passed the patched `test_deep_nesting` cleanup regression on macOS
- passed all 28 upstream json-c tests in the prior Linux Release validation
- reproduced the 0.19 leak under Valgrind before the fixes
- confirmed zero bytes in use at exit with the complete fixes
- validated that all 14 recipe targets reference the patch

CLAM-3061
